### PR TITLE
New boolean param for user to choose to hide empty stats (#176)

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -27,6 +27,7 @@ disableLanguages        = []
   readingTime           = true
   imageStretch          = ""
   socialShare           = ["twitter", "facebook", "reddit", "linkedin", "pinterest", "email"]
+  hideEmptyStats        = false
 
   [params.meta]
     description         = "A theme by HTML5 UP, ported by Julio Pescador. Slimmed and enhanced by Patrick Collins. Multilingual by StatnMap. Powered by Hugo."

--- a/layouts/_default/stats.html
+++ b/layouts/_default/stats.html
@@ -1,24 +1,30 @@
 <div class="stats">
-  <ul class="categories">
-    {{ if isset .Params "categories" }}
-      {{ if gt (len .Params.categories) 0 }}
-        {{ range .Params.categories }}
+  {{ if .Params.categories }}
+    <ul class="categories">
+      {{ with .Params.categories }}
+        {{ range . }}
           <li><a class="article-terms-link" href="{{ path.Join "categories" (. | urlize | lower) | relLangURL }}/">{{ . }}</a></li>
         {{ end }}
       {{ end }}
-    {{ else }}
+    </ul>
+  {{ else if .Site.Params.hideEmptyStats }}
+  {{ else }}
+    <ul class="categories">
       <li>None</li>
-    {{ end }}
-  </ul>
-  <ul class="tags">
-    {{ if isset .Params "tags" }}
-      {{ if gt (len .Params.tags) 0 }}
-        {{ range .Params.tags }}
+    </ul>
+  {{ end }}
+  {{ if .Params.tags }}
+    <ul class="tags">
+      {{ with .Params.tags }}
+        {{ range . }}
           <li><a class="article-terms-link" href="{{ path.Join "tags" (. | urlize | lower) | relLangURL }}/">{{ . }}</a></li>
         {{ end }}
       {{ end }}
-    {{ else }}
+    </ul>
+  {{ else if .Site.Params.hideEmptyStats }}
+  {{ else }}
+    <ul class="tags">
       <li>None</li>
-    {{ end }}
-  </ul>
+    </ul>
+  {{ end }}
 </div>


### PR DESCRIPTION
* new boolean param for user to choose to hide empty stats

* refactor logic; address comments

* remove unnecessary isset from stats

* clean the stats ranges a little

## Description

[Describe your changes in detail]

## Motivation and Context

[Why is this change required? What problem does it solve?]

[If it fixes an open issue, please link to the issue here by writing "Closes #XXX"]

## Screenshots (if appropriate):

[You can use `Windows+Shift+S` or `Control+Command+Shift+4` to add a screenshot to your clipboard and then paste it here.]

## Checklist:

- [x] I have updated the [documentation](https://github.com/pacollins/hugo-future-imperfect-slim/wiki), as applicable.
- [x] I have updated the `theme.toml`, as applicable.
